### PR TITLE
Width and Height now set from viewport dimensions

### DIFF
--- a/Source/Holodeck/Sensors/Private/HolodeckViewportClientPublisher.cpp
+++ b/Source/Holodeck/Sensors/Private/HolodeckViewportClientPublisher.cpp
@@ -6,6 +6,12 @@
 // Sets default values for this component's properties
 UHolodeckViewportClientPublisher::UHolodeckViewportClientPublisher() : Width(512), Height(512) {
 	PrimaryComponentTick.bCanEverTick = true;
+	FVector2D ViewportDimensions;
+	if (GEngine && GEngine->GameViewport)	{
+		GEngine->GameViewport->GetViewportSize(ViewportDimensions);
+		Width = ViewportDimensions.X;
+		Height = ViewportDimensions.Y;
+	}
 }
 
 void UHolodeckViewportClientPublisher::BeginPlay() {


### PR DESCRIPTION
It's just a fix to the holodeck viewport crashing because it tries to write outside of the buffer's bounds. There is more to fix in the viewport bug, this is just a part of it. 