### PR TITLE
Added UPROPERTY() to prevent garbage collection

### DIFF
--- a/Source/Holodeck/ClientCommands/Public/CommandCenter.h
+++ b/Source/Holodeck/ClientCommands/Public/CommandCenter.h
@@ -74,6 +74,7 @@ private:
 	  */
 	int ReadCommandBuffer();
 	
+	UPROPERTY()
 	TArray<UCommand*> Commands;
 	char* Buffer;
 	bool* ShouldReadBufferPtr;

--- a/Source/Holodeck/HolodeckCore/Public/HolodeckGameMode.h
+++ b/Source/Holodeck/HolodeckCore/Public/HolodeckGameMode.h
@@ -63,6 +63,8 @@ private:
 
 	UPROPERTY()
 	UHolodeckServer* Server;
+	UPROPERTY()
 	UHolodeckGameInstance* Instance;
+	UPROPERTY()
 	UCommandCenter* CommandCenter;
 };


### PR DESCRIPTION
I didn't account for the command center getting garbage collected. Unreal engine systematically collected it at the same point every time. Remember to use UPROPERTY() on your member variables pointers!