### PR TITLE
Add profiling macros to RenderRequest

### DIFF
--- a/Source/Holodeck/General/Private/RenderRequest.cpp
+++ b/Source/Holodeck/General/Private/RenderRequest.cpp
@@ -1,6 +1,10 @@
 #include "Holodeck.h"
 #include "RenderRequest.h"
 
+DEFINE_STAT(STAT_CameraExecuteTask);
+DEFINE_STAT(STAT_CameraExecuteTask_ReadSurfaceData);
+DEFINE_STAT(STAT_CameraExecuteTask_Memcpy);
+
 void FRenderRequest::RetrievePixels(FColor* PixelBuffer, UTextureRenderTarget2D* Texture) {
 	this->Buffer = PixelBuffer;
 	this->TargetTexture = Texture;
@@ -12,6 +16,9 @@ void FRenderRequest::RetrievePixels(FColor* PixelBuffer, UTextureRenderTarget2D*
 
 void FRenderRequest::ExecuteTask()
 {
+	SCOPE_CYCLE_COUNTER(STAT_CameraExecuteTask);
+
+
 	TArray<FColor> SurfaceData;
 	FRHICommandListImmediate& RHICmdList = GetImmediateCommandList_ForRenderCommand();
 	FTextureRenderTargetResource*  rt_resource = TargetTexture->GetRenderTargetResource();
@@ -21,13 +28,22 @@ void FRenderRequest::ExecuteTask()
 		FIntPoint size;
 		FReadSurfaceDataFlags flags(RCM_UNorm, CubeFace_MAX);
 		flags.SetLinearToGamma(false);
-		RHICmdList.ReadSurfaceData(
-			rhi_texture,
-			FIntRect(0, 0, TargetTexture->SizeX, TargetTexture->SizeY),
-			SurfaceData,
-			flags);
 
-		FMemory::Memcpy(this->Buffer, &SurfaceData[0], SurfaceData.Num() * sizeof(FColor)); // this line isn't the problem
+		{
+			SCOPE_CYCLE_COUNTER(STAT_CameraExecuteTask_ReadSurfaceData);
+			// This next call is slow! Significant impact on the frame time (~8ms)
+			RHICmdList.ReadSurfaceData(
+				rhi_texture,
+				FIntRect(0, 0, TargetTexture->SizeX, TargetTexture->SizeY),
+				SurfaceData,
+				flags);
+		}
+
+		{
+			SCOPE_CYCLE_COUNTER(STAT_CameraExecuteTask_Memcpy);
+			FMemory::Memcpy(this->Buffer, &SurfaceData[0], SurfaceData.Num() * sizeof(FColor)); // this line isn't the problem
+		}
+
 	}
 }
 

--- a/Source/Holodeck/General/Public/RenderRequest.h
+++ b/Source/Holodeck/General/Public/RenderRequest.h
@@ -8,6 +8,10 @@
 // Adapted from Microsoft Airsim Open Source Project
 // https://github.com/Microsoft/AirSim/blob/7bddd5857791f9c164e8eba80c229f199c0babf8/Unreal/Plugins/AirSim/Source/RenderRequest.h
 
+DECLARE_STATS_GROUP(TEXT("RenderRequest"), STATGROUP_RenderRequest, STATCAT_Advanced);
+DECLARE_CYCLE_STAT_EXTERN(TEXT("CameraExecuteTask"), STAT_CameraExecuteTask, STATGROUP_RenderRequest, );
+DECLARE_CYCLE_STAT_EXTERN(TEXT("CameraExecuteTask_ReadSurfaceData"), STAT_CameraExecuteTask_ReadSurfaceData, STATGROUP_RenderRequest, );
+DECLARE_CYCLE_STAT_EXTERN(TEXT("CameraExecuteTask_Memcpy"), STAT_CameraExecuteTask_Memcpy, STATGROUP_RenderRequest, );
 
 class FRenderRequest : public FRenderCommand
 {
@@ -19,7 +23,7 @@ class FRenderRequest : public FRenderCommand
 		virtual ~FRenderRequest() final;
 
 		/**
-		* Retrieves the rendered texture from the GPU without flushing the GPU like ReadPixels() does. 
+		* Retrieves the rendered texture from the GPU without flushing the GPU like ReadPixels() does.
 		*/
 		virtual void RetrievePixels(FColor* Buffer, UTextureRenderTarget2D* TargetTexture);
 


### PR DESCRIPTION
Add the macros to define stat counters for RenderRequst. This allows the session frontend to be used to monitor the performance of the RGB Cameras.

See https://github.com/BYU-PCCL/holodeck-engine/wiki/Using-the-UE4-Profiler and BYU-PCCL/holodeck#131 for more information.