### PR TITLE
Add render quality adjustment command

### DIFF
--- a/Source/Holodeck/ClientCommands/Private/CommandFactory.cpp
+++ b/Source/Holodeck/ClientCommands/Private/CommandFactory.cpp
@@ -11,7 +11,8 @@ UCommand* UCommandFactory::MakeCommand(const std::string& Name, const std::vecto
 										  { "SetWeather", &CreateInstance<USetWeatherCommand> },
 										  { "DayCycle", &CreateInstance<UDayCycleCommand> },
 										  { "TeleportCamera", &CreateInstance<UTeleportCameraCommand> },
-										  { "RenderViewport", &CreateInstance<URenderViewportCommand> } };
+										  { "RenderViewport", &CreateInstance<URenderViewportCommand> },
+										  { "AdjustRenderQuality", &CreateInstance<UAdjustRenderQualityCommand> } };
 	UCommand*(*CreateCommandFunction)()  = CommandMap[Name];
 	UCommand* ToReturn = nullptr;
 	if (CreateCommandFunction) {

--- a/Source/Holodeck/ClientCommands/Public/AdjustRenderQualityCommand.cpp
+++ b/Source/Holodeck/ClientCommands/Public/AdjustRenderQualityCommand.cpp
@@ -1,0 +1,40 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "Holodeck.h"
+#include "HolodeckGameMode.h"
+#include "AdjustRenderQualityCommand.h"
+
+void UAdjustRenderQualityCommand::Execute() {
+	UE_LOG(LogHolodeck, Log, TEXT("UAdjustRenderQualityCommand::Execute change render quality"));
+
+	if (StringParams.size() != 0 || NumberParams.size() != 1) {
+		UE_LOG(LogHolodeck, Error, TEXT("Unexpected argument length found in UAdjustRenderQualityCommand. Command not executed."));
+		return;
+	}
+
+	UGameUserSettings* settings = GEngine->GetGameUserSettings();
+
+	// 0 = worst quality, 3 = best
+	// see 
+	int quality = NumberParams[0];
+
+	if (quality < 0 || quality > 3)	{
+		UE_LOG(LogHolodeck, Warning, TEXT("Invalid quality passed to UAdjustRenderQualityCommand!"));
+		return;
+	}
+
+	settings->SetOverallScalabilityLevel(quality);
+
+	if (quality == 0) {
+		// quality 0 will set the ScreenPercentage to 50. If the users wants to lower the resolution of the viewport or camera,
+		// there are better ways of doing so, so force the scale to be 1 (100%)
+		settings->SetResolutionScaleNormalized(1.0f);
+	}
+
+	// Apply the settings (these function calls are what ApplySettings() does) without writing the config out to disk
+	// this is to prevent changes from persisting between holodeck instances
+	settings->ApplyResolutionSettings(false);
+	settings->ApplyNonResolutionSettings();
+
+	UE_LOG(LogHolodeck, Log, TEXT("UAdjustRenderQualityCommand was successful"));
+}

--- a/Source/Holodeck/ClientCommands/Public/AdjustRenderQualityCommand.h
+++ b/Source/Holodeck/ClientCommands/Public/AdjustRenderQualityCommand.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Holodeck.h"
+
+#include "Command.h"
+#include "AdjustRenderQualityCommand.generated.h"
+
+/**
+* AdjustRenderQualityCommand
+* The command used to alter the fidelity of the simulation.
+*
+* StringParameters are expected to be empty.
+* NumberParameters are expected to be an integer between 0 and 3 inclusive
+*
+*/
+UCLASS(ClassGroup = (Custom))
+class HOLODECK_API UAdjustRenderQualityCommand : public UCommand
+{
+	GENERATED_BODY()
+
+public:
+	// See UCommand for the documentation of this overridden function. 
+	void Execute() override;
+};

--- a/Source/Holodeck/ClientCommands/Public/CommandFactory.h
+++ b/Source/Holodeck/ClientCommands/Public/CommandFactory.h
@@ -13,6 +13,7 @@
 #include "SetWeatherCommand.h"
 #include "TeleportCameraCommand.h"
 #include "RenderViewportCommand.h"
+#include "AdjustRenderQualityCommand.h"
 #include "CommandFactory.generated.h"
 
 class AHolodeckGameMode;


### PR DESCRIPTION
Adds a command that allows the overall scalability quality to be set

See https://docs.unrealengine.com/en-us/Engine/Performance/Scalability/ScalabilityReference

Implements  BYU-PCCL/holodeck#136