### PR TITLE
Fixes precompiled header warning and set camera rate bug

### DIFF
--- a/Source/Holodeck/ClientCommands/Private/RGBCameraRateCommand.cpp
+++ b/Source/Holodeck/ClientCommands/Private/RGBCameraRateCommand.cpp
@@ -27,6 +27,12 @@ void URGBCameraRateCommand::Execute() {
 	int ticksPerCapture = NumberParams[0];
 
 	AHolodeckAgent* Agent = GetAgent(AgentName);
+
+	if (!Agent->SensorMap.Contains("RGBCamera")) {
+		UE_LOG(LogHolodeck, Warning, TEXT("RGBCameraRateCommand::Execute No camera found on agent."));
+		return;
+	}
+
 	URGBCamera* Camera = (URGBCamera*)Agent->SensorMap["RGBCamera"];
 	Camera->TicksPerCapture = ticksPerCapture;
 }

--- a/Source/Holodeck/Holodeck.Build.cs
+++ b/Source/Holodeck/Holodeck.Build.cs
@@ -6,6 +6,7 @@ public class Holodeck : ModuleRules
 {
 	public Holodeck(ReadOnlyTargetRules Target) : base(Target)
 	{
+        PrivatePCHHeaderFile = "Holodeck.h";
         PrivateIncludePaths.AddRange(new [] {
              "Holodeck/Agents/Public",
              "Holodeck/General/Public",


### PR DESCRIPTION
C:\Users\Nick Walton\Desktop\holodeck-engine\Source\Holodeck\Holodeck.Build.cs : warning : Modules must specify an explicit precompiled header (eg. PrivatePCHHeaderFile = "Holodeck.h") from UE 4.21 onwards.