### PR TITLE
Don't steal mouse on startup

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -54,8 +54,8 @@ bEnableMouseSmoothing=True
 bEnableFOVScaling=True
 FOVScale=0.011110
 DoubleClickTime=0.200000
-bCaptureMouseOnLaunch=True
-DefaultViewportMouseCaptureMode=CapturePermanently_IncludingInitialMouseDown
+bCaptureMouseOnLaunch=False
+DefaultViewportMouseCaptureMode=CaptureDuringMouseDown
 bDefaultViewportMouseLock=True
 bAlwaysShowTouchInterface=False
 bShowConsoleOnFourFingerTap=True
@@ -63,5 +63,4 @@ DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.Defaul
 ConsoleKey=None
 -ConsoleKeys=Tilde
 +ConsoleKeys=Tilde
-
 


### PR DESCRIPTION
Prevents the engine from capturing the mouse on startup
If you click down on the window, it will capture the mouse
so you can pan the camera around.