### PR TITLE
Delete workspace when build finishes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline
 					sh "tar -zcvf holodeck-engine.tar.gz dist/"
 					archiveArtifacts artifacts:'holodeck-engine.tar.gz', fingerprint: true
 				}
-				cleaup {
+				cleanup {
 					cleanupWs()
 				}
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,9 @@ pipeline
 					sh "tar -zcvf holodeck-engine.tar.gz dist/"
 					archiveArtifacts artifacts:'holodeck-engine.tar.gz', fingerprint: true
 				}
+				cleaup {
+					cleanupWs()
+				}
 			}
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline
 					archiveArtifacts artifacts:'holodeck-engine.tar.gz', fingerprint: true
 				}
 				cleanup {
-					cleanupWs()
+					cleanWs()
 				}
 			}
 		}


### PR DESCRIPTION
Avoids multiple terabytes of disk usage