### PR TITLE
Added camera socket to agent meshes

### DIFF
--- a/Content/HolodeckContent/Agents/SphereRobot/SphereRobotBody.uasset
+++ b/Content/HolodeckContent/Agents/SphereRobot/SphereRobotBody.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d9940a7fc7e1edff2c8589bf442c3c2eafad60b00fd8ee95d5dc70afc656573
-size 255438
+oid sha256:9765de63c681a63f22b6136c7dd6c382873a6828548fc469e2109eaf9ff4067e
+size 255671

--- a/Content/HolodeckContent/Agents/TurtleAgent/TurtleBody.uasset
+++ b/Content/HolodeckContent/Agents/TurtleAgent/TurtleBody.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6665a0ed3fa748ec3856577ae85cc3ea48aec3d467ea949587f774384144a391
-size 171979
+oid sha256:55604aa30d417bde448aaba6f7a3621c2fabe652a47d20f4c84fb98915f4f60b
+size 172123

--- a/Content/HolodeckContent/Agents/UAV/UAVMesh/UavNoCameraNoBlades.uasset
+++ b/Content/HolodeckContent/Agents/UAV/UAVMesh/UavNoCameraNoBlades.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97f83dddf35b8ce2b8a3f27cb3adddc8ca26049082907622ea5d19fdb68a9daf
-size 8653946
+oid sha256:5705403af5c3f013bfb1c4c0321459ad34fbd44395f363085491b332b68a2f0d
+size 8654606


### PR DESCRIPTION
Added CameraSocket to the uav, sphere robot, and turtle bot. The android already had one and the nav agent doesn't need one (and is also glitchy).