### PR TITLE
Fixed a bug where on Linux the control scheme wasn't reflecting on th…

### DIFF
--- a/Source/Holodeck/ClientCommands/Private/SpawnAgentCommand.cpp
+++ b/Source/Holodeck/ClientCommands/Private/SpawnAgentCommand.cpp
@@ -26,7 +26,7 @@ void USpawnAgentCommand::Execute() {
 	// Note that we have to re-order the parameters since FRotator takes pitch, roll, yaw
 	// but the coordinates from the Python side com in roll, pitch, yaw order
 	FRotator Rotation = FRotator(NumberParams[4], NumberParams[3], NumberParams[5]);
-	bool IsMainAgent = NumberParams[6];
+	bool IsMainAgent = (bool) NumberParams[6];
 
 	Location = ConvertLinearVector(Location, ClientToUE);
 

--- a/Source/Holodeck/HolodeckCore/Private/HolodeckSharedMemory.cpp
+++ b/Source/Holodeck/HolodeckCore/Private/HolodeckSharedMemory.cpp
@@ -62,7 +62,7 @@ HolodeckSharedMemory::HolodeckSharedMemory(const std::string& Name, unsigned int
 
 	#elif PLATFORM_LINUX
 
-    MemFile = shm_open(MemPath.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0777);
+    MemFile = shm_open(MemPath.c_str(), O_CREAT | O_RDWR, 0777);
     ftruncate(MemFile, this->MemSize);
     MemPointer = static_cast<void*>(mmap(nullptr, this->MemSize, PROT_READ | PROT_WRITE,
                                          MAP_SHARED, MemFile, 0));


### PR DESCRIPTION
Fixed a bug where on Linux the control scheme wasn't reflecting on the server when initially set by the client. This was because we were using the O_TRUNC flag when initializing shared memory on the server. This results in the memory buffer being initialized to zero bytes (overriding whatever the client initially stored).

I ran the test and a few more tests passed on Linux because of the fix. Some tests that resulted in an error now fail (which I think is an improvement). No passing test was affected. See the comparison below.

![local_with_change](https://user-images.githubusercontent.com/20961140/69105078-80da1680-0a27-11ea-9eac-3c2af352e58d.png)
![published_version](https://user-images.githubusercontent.com/20961140/69105080-80da1680-0a27-11ea-8889-e872955b059e.png)

