### PR TITLE
Fixed manually adding agent bug

### DIFF
--- a/Source/Holodeck/HolodeckCore/Private/HolodeckPawnController.cpp
+++ b/Source/Holodeck/HolodeckCore/Private/HolodeckPawnController.cpp
@@ -34,10 +34,6 @@ void AHolodeckPawnController::OnPossess(APawn* InPawn) {
 	UE_LOG(LogHolodeck, Log, TEXT("Pawn Possessed: %s, Controlled by: %s"), *InPawn->GetHumanReadableName(), *this->GetClass()->GetName());
 	UpdateServerInfo();
 
-	if (Server == nullptr) {
-		UE_LOG(LogHolodeck, Fatal, TEXT("HolodeckPawnController couldn't find server..."));
-	}
-
 	URawControlScheme* RawControlScheme = NewObject<URawControlScheme>();
 	RawControlScheme->Agent = ControlledAgent;
 	ControlSchemes.Add(RawControlScheme);
@@ -46,6 +42,10 @@ void AHolodeckPawnController::OnPossess(APawn* InPawn) {
 
 void AHolodeckPawnController::Tick(float DeltaSeconds) {
 	Super::Tick(DeltaSeconds);
+
+	if (Server == nullptr) {
+		UE_LOG(LogHolodeck, Fatal, TEXT("HolodeckPawnController couldn't find server..."));
+	}
 
 	if (ShouldChangeStateBuffer && *ShouldChangeStateBuffer & 0x4) {
 		ExecuteSetState();

--- a/Source/Holodeck/HolodeckCore/Public/HolodeckAgentInterface.h
+++ b/Source/Holodeck/HolodeckCore/Public/HolodeckAgentInterface.h
@@ -104,7 +104,7 @@ public:
 	};
 
 	// Must be set in the editor.
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 		FString AgentName;
 
 	UPROPERTY(BlueprintReadWrite)


### PR DESCRIPTION
Fixed BYU-PCCL/holodeck#361 bug. The holodeck pawn controller OnPossess function was being called before the agent had been initialized. Because this function is built into the pawn controller class and it was being called before any function in the agent, the check for the server had to be moved into the tick function. Now it is always called after the initialization function.

Additionally, the EditAnywhere property had to be added to the AgentName to allow the user to edit the agent name from the editor.