### PR TITLE
Don't even try to unlink the LoadingSemaphore

### DIFF
--- a/Source/Holodeck/HolodeckCore/Private/HolodeckServer.cpp
+++ b/Source/Holodeck/HolodeckCore/Private/HolodeckServer.cpp
@@ -35,11 +35,6 @@ void UHolodeckServer::Start() {
         LogSystemError("Unable to open loading semaphore");
     }
 
-    int status = sem_post(LoadingSemaphore);
-    if (status == -1) {
-        LogSystemError("Unable to update loading semaphore");
-    }
-
     LockingSemaphore1 = sem_open(TCHAR_TO_ANSI(*(SEMAPHORE_PATH1 + UUID)), O_CREAT, 0777, 1);
     if (LockingSemaphore1 == SEM_FAILED) {
         LogSystemError("Unable to open server semaphore");
@@ -50,10 +45,12 @@ void UHolodeckServer::Start() {
         LogSystemError("Unable to open client semaphore");
     }
 
-    status = sem_unlink(LOADING_SEMAPHORE_PATH);
+	int status = sem_post(LoadingSemaphore);
     if (status == -1) {
-        LogSystemError("Unable to close loading semaphore");
+        LogSystemError("Unable to update loading semaphore");
     }
+
+    // Client unlinks LoadingSemaphore
 #endif
 
     bIsRunning = true;
@@ -125,6 +122,5 @@ bool UHolodeckServer::IsRunning() const {
 }
 
 void UHolodeckServer::LogSystemError(const std::string& errorMessage) {
-    std::string errorMsg = errorMessage + " - Error code: " + std::to_string(errno) + " - " + std::string(strerror(errno));
-    UE_LOG(LogHolodeck, Fatal, TEXT("%s"), ANSI_TO_TCHAR(errorMessage.c_str()));
+    UE_LOG(LogHolodeck, Fatal, TEXT("%s - Error code: %d=%s"), ANSI_TO_TCHAR(errorMessage.c_str()), errno, ANSI_TO_TCHAR(strerror(errno)));
 }

--- a/Source/Holodeck/HolodeckCore/Private/HolodeckServer.cpp
+++ b/Source/Holodeck/HolodeckCore/Private/HolodeckServer.cpp
@@ -45,7 +45,7 @@ void UHolodeckServer::Start() {
         LogSystemError("Unable to open client semaphore");
     }
 
-	int status = sem_post(LoadingSemaphore);
+    int status = sem_post(LoadingSemaphore);
     if (status == -1) {
         LogSystemError("Unable to update loading semaphore");
     }


### PR DESCRIPTION
It wasn't unlinking correctly because it didn't have the UUID. Adding the UUID caused more problems though because the client expects to be able to unlink the semaphore, so it's best to just skip it.

I also moved the `sem_post` for LoadingSemaphore until after the engine has opened it's semaphores as a wild, unsubstantiated stab at fixing the semaphore busy error.

Fixed the error logging method too.
