### PR TITLE
Fix shared memory size of "command_buffer"

### DIFF
--- a/Source/Holodeck/ClientCommands/Private/CommandCenter.cpp
+++ b/Source/Holodeck/ClientCommands/Private/CommandCenter.cpp
@@ -6,7 +6,6 @@ const FString UCommandCenter::BUFFER_NAME = "command_buffer";
 const FString UCommandCenter::BUFFER_SHOULD_READ_NAME = "command_bool";
 const int UCommandCenter::BUFFER_SHOULD_READ_SIZE = 1;
 const int UCommandCenter::BUFFER_SIZE = 1048576; //one megabyte
-const int UCommandCenter::BYTE_SIZE = 8;
 
 void UCommandCenter::GiveCommand(UCommand * const Input) {
 	if (Input != nullptr)
@@ -32,7 +31,7 @@ void UCommandCenter::GetCommandBuffer() {
 	if (Server == nullptr) {
 		UE_LOG(LogHolodeck, Warning, TEXT("CommandCenter could not find server..."));
 	} else {
-		Buffer = static_cast<char*>(Server->Malloc(TCHAR_TO_UTF8(*BUFFER_NAME), BUFFER_SIZE * BYTE_SIZE));
+		Buffer = static_cast<char*>(Server->Malloc(TCHAR_TO_UTF8(*BUFFER_NAME), BUFFER_SIZE));
 
 		if (!Buffer) {
 			UE_LOG(LogHolodeck, Fatal, TEXT("CommandCenter::GetCommandBuffer: Failed to allocate shared memory for buffer!"));

--- a/Source/Holodeck/ClientCommands/Public/CommandCenter.h
+++ b/Source/Holodeck/ClientCommands/Public/CommandCenter.h
@@ -84,7 +84,6 @@ private:
 	const static FString BUFFER_SHOULD_READ_NAME;
 	const static int BUFFER_SHOULD_READ_SIZE;
 	const static int BUFFER_SIZE;
-	const static int BYTE_SIZE;
 
 	/**
 	  * ExctractCommandsFromJson


### PR DESCRIPTION
If I'm not mistaken, Server->Malloc() takes the buffer size in bytes, not bits. So the whole constant UCommandCenter::BYTE_SIZE is not needed (or at the least, the constant should be equal to 1, not 8).
From what I see on my machine, the engine currently allocates 8 times too much memory for "command_buffer", when compared to the client. (engine: 8388608 vs. client: 1048576). This changes fixes that.